### PR TITLE
add /txos/<txo_pubkey or key_image> endpoint for hyperlinking to a block

### DIFF
--- a/src/api/loaders.ts
+++ b/src/api/loaders.ts
@@ -5,18 +5,22 @@ import getBlock from "api/getBlock";
 import getMintInfo from "api/getMintInfo";
 import getBurns from "api/getBurns";
 import getNetworkStatus from "api/getNetworkStatus";
+import searchBlock from "api/searchBlock";
 
-const getLatestBlock = async () => {
-    const latestBlocks = await getRecentBlocks(1);
-    const latestBlockIndex = latestBlocks[0].index;
-    const blockContents = await getBlock(latestBlockIndex);
-    const mintInfo = await getMintInfo(latestBlockIndex);
-    const burns = await getBurns(latestBlockIndex);
+const getBlockInfo = async (blockIndex) => {
+    const blockContents = await getBlock(blockIndex);
+    const mintInfo = await getMintInfo(blockIndex);
+    const burns = await getBurns(blockIndex);
     return {
         blockContents,
         mintInfo,
         burns
     };
+};
+
+const getLatestBlock = async () => {
+    const latestBlocks = await getRecentBlocks(1);
+    return getBlockInfo(latestBlocks[0].index);
 };
 
 export async function latestBlockLoader() {
@@ -38,12 +42,14 @@ export async function recentBlocksLoader() {
 }
 
 export async function currentBlockLoader({ params }) {
-    const blockContents = await getBlock(params.blockIndex);
-    const mintInfo = await getMintInfo(params.blockIndex);
-    const burns = await getBurns(params.blockIndex);
-    return {
-        blockContents,
-        mintInfo,
-        burns
-    };
+    return getBlockInfo(params.blockIndex);
+}
+
+export async function byTxoCurrentBlockLoader({ params }) {
+    const foundBlock = await searchBlock(params.pubKeyOrKeyImage.trim());
+    if (foundBlock) {
+        return getBlockInfo(foundBlock.block.index);
+    } else {
+        throw new Error(params.pubKeyOrKeyImage);
+    }
 }

--- a/src/pages/TxoNotFoundPage.tsx
+++ b/src/pages/TxoNotFoundPage.tsx
@@ -1,0 +1,33 @@
+import { Box, Typography, Container, Link } from "@mui/material";
+import { useRouteError } from "react-router-dom";
+
+export default function ErrorPage() {
+    const error = useRouteError();
+    return <ErrorWrapper errorText={getErrorMessage(error)} />;
+}
+
+function ErrorWrapper({ errorText }: { errorText?: string }) {
+    return (
+        <Container>
+            <Box>
+                <Box sx={{ marginBottom: 1 }}>
+                    <Typography variant="h6">
+                        No matching TXO Public Key or Key Image was found
+                    </Typography>
+                    <Typography sx={{ fontSize: 14 }} color="text.secondary">
+                        searching for: {errorText}
+                    </Typography>
+                    <Typography>&nbsp;</Typography>
+                    <Link href="/blocks" sx={{ marginBottom: 4 }}>
+                        view recent blocks
+                    </Link>
+                </Box>
+            </Box>
+        </Container>
+    );
+}
+
+function getErrorMessage(error: unknown): string {
+    if (error instanceof Error) return error.message;
+    return JSON.stringify(error);
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -3,12 +3,14 @@ import LatestBlocks from "pages/LatestBlocks";
 import CurrentBlock from "pages/CurrentBlock";
 import LatestBlock from "pages/LatestBlock";
 import ErrorPage from "pages/ErrorPage";
+import TxoNotFoundPage from "pages/TxoNotFoundPage";
 import Layout from "pages/Layout";
 import {
     layoutLoader,
     latestBlockLoader,
     recentBlocksLoader,
-    currentBlockLoader
+    currentBlockLoader,
+    byTxoCurrentBlockLoader
 } from "api/loaders";
 
 const router = createBrowserRouter([
@@ -43,6 +45,12 @@ const router = createBrowserRouter([
                 },
                 loader: currentBlockLoader,
                 element: <CurrentBlock />
+            },
+            {
+                path: "txos/:pubKeyOrKeyImage",
+                loader: byTxoCurrentBlockLoader,
+                element: <CurrentBlock />,
+                errorElement: <TxoNotFoundPage />
             }
         ]
     }


### PR DESCRIPTION
With this PR the block-explorer becomes more useful to exchanges, ramp providers, and anyone else who in addition to displaying a TXO Public Key, wants to give their customer / counterparty a direct hyperlink to the block explorer that will display the relevant block.

The new endpoint can also be used to hyperlink a block based on a contained Key Image.