### PR TITLE
move search error snackbar to top of page for better visibility

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -149,7 +149,7 @@ export default function Header({ networkStatus }: { networkStatus: NetworkStatus
                 onClose={() => setSnackbarOpen(false)}
                 sx={{ backgroundColor: "theme.palette.warning.main" }}
                 anchorOrigin={{
-                    vertical: "bottom",
+                    vertical: "top",
                     horizontal: "center"
                 }}
             >


### PR DESCRIPTION
Prior to this PR, a search error popped open a snackbar at the bottom of the page that was easy to miss.

Now the snackbar will appear pretty much on top of the search box so that the user sees the error.