### PR TITLE
display block ids rather than block contenthash

### DIFF
--- a/src/components/CopyableField.tsx
+++ b/src/components/CopyableField.tsx
@@ -5,9 +5,11 @@ import { abbreviateHash } from "utils/truncate";
 
 export default function CopyableField({
     text,
+    name,
     abbreviate = true
 }: {
     text: string;
+    name?: string;
     abbreviate?: boolean;
 }) {
     function copyToClipboard(e: React.MouseEvent<HTMLButtonElement>) {
@@ -16,6 +18,7 @@ export default function CopyableField({
     }
 
     const renderedText = abbreviate ? abbreviateHash(text) : text;
+    const renderedField = name ? name + ": " + renderedText : renderedText;
 
     return (
         <Box display="flex" alignItems="center">
@@ -27,7 +30,7 @@ export default function CopyableField({
                     />
                 </IconButton>
             </Tooltip>
-            <Typography sx={{ fontSize: 14 }}>{renderedText}</Typography>
+            <Typography sx={{ fontSize: 14 }}>{renderedField}</Typography>
         </Box>
     );
 }

--- a/src/components/current-block/CurrentBlock.tsx
+++ b/src/components/current-block/CurrentBlock.tsx
@@ -49,7 +49,7 @@ export default function CurrentBlock({ blockContents, mintInfo, burns }: BlockIn
                 <Box sx={{ marginBottom: 1 }}>
                     <Typography variant="h4">Block {blockContents.index}</Typography>
                     <Typography color="text.secondary">{getTimeStamp(blockContents)}</Typography>
-                    <CopyableField text={blockContents.contentsHash} abbreviate={matches} />
+                    <CopyableField text={blockContents.id} name="Id" abbreviate={matches} />
                 </Box>
                 <Box sx={{ display: "flex" }}>
                     {isPrevDisabled ? (

--- a/src/components/latest-blocks/BlockRow.tsx
+++ b/src/components/latest-blocks/BlockRow.tsx
@@ -41,7 +41,7 @@ export default function BlockRow({ block }: BlockRowProps) {
         <StyledTableRow onClick={goToBlock} hover>
             <StyledTableCell style={{ borderLeft: borderStyle }}>{block.index}</StyledTableCell>
             <StyledTableCell>
-                <CopyableField text={block.contentsHash} />
+                <CopyableField text={block.id} />
             </StyledTableCell>
             <StyledTableCell>{block.outputs.length}</StyledTableCell>
             <StyledTableCell>{block.keyImages.length}</StyledTableCell>

--- a/src/components/latest-blocks/LatestBlocksLoaded.tsx
+++ b/src/components/latest-blocks/LatestBlocksLoaded.tsx
@@ -127,7 +127,7 @@ export default function LatestBlocksLoaded({ preLoadedBlocks }: { preLoadedBlock
                     <TableHead>
                         <TableRow>
                             <TableCell>Index</TableCell>
-                            <TableCell>Hash</TableCell>
+                            <TableCell>Id</TableCell>
                             <TableCell>TXOs</TableCell>
                             <TableCell>IMGs</TableCell>
                             <TableCell>SIGs</TableCell>


### PR DESCRIPTION
The block explorer is current showing the block contentHash for each block, but the block Id is a more comprehensive hash of the block contents and therefore a more useful item to display. 

This PR swaps out displaying the block contentHash and instead displays the block Id.

It also extends CopyableField so that it can optionally display the name of the field, motivated by wanting to tag the display of the block Id as just that, rather than simply displaying an anonymous hex string.